### PR TITLE
Mange missing log_dir for icingadb-redis

### DIFF
--- a/manifests/redis/install.pp
+++ b/manifests/redis/install.pp
@@ -10,10 +10,27 @@ class icingadb::redis::install {
 
   $package_name    = $icingadb::redis::globals::package_name
   $manage_packages = $icingadb::redis::manage_packages
+  $user            = $icingadb::redis::globals::user
+  $log_dir         = $icingadb::redis::globals::log_dir
+
+  if $facts['os']['family'] == 'Debian' {
+    $group = 'adm'
+    $mode  = '2750'
+  } else {
+    $group = $icingadb::redis::globals::group
+    $mode  = '0750'
+  }
 
   if $manage_packages {
     package { $package_name:
       ensure => installed,
+    }
+
+    file { $log_dir:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+      mode   => $mode,
     }
   }
 }


### PR DESCRIPTION
Since icingadb-redis package v7.0.15-1 the default log method is syslog and the log_dir was removed from package.