### PR TITLE
Add missing database options in class icingadb

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -77,6 +77,7 @@ The following parameters are available in the `icingadb` class:
 * [`db_tls_key_file`](#-icingadb--db_tls_key_file)
 * [`db_tls_cacert`](#-icingadb--db_tls_cacert)
 * [`db_tls_cacert_file`](#-icingadb--db_tls_cacert_file)
+* [`db_options`](#-icingadb--db_options)
 * [`logging_level`](#-icingadb--logging_level)
 * [`logging_output`](#-icingadb--logging_output)
 * [`logging_interval`](#-icingadb--logging_interval)
@@ -324,6 +325,25 @@ Data type: `Optional[Stdlib::Absolutepath]`
 Location of the CA root certificate. Only valid if `db_use_tls` is turned on.
 
 Default value: `undef`
+
+##### <a name="-icingadb--db_options"></a>`db_options`
+
+Data type:
+
+```puppet
+Hash[Enum[
+      'max_connections',
+      'max_connections_per_table',
+      'max_placeholders_per_statement',
+      'max_rows_per_transaction',
+      'wsrep_sync_wait'
+  ], Integer[1]]
+```
+
+List of low-level database options that can be set to influence some
+Icinga DB internal default behaviours.
+
+Default value: `{}`
 
 ##### <a name="-icingadb--logging_level"></a>`logging_level`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,7 @@ class icingadb::config {
         db_tls_key             => $db_tls_files['key_file'],
         db_tls_cacert          => $db_tls_files['cacert_file'],
         db_tls_insecure        => $icingadb::db_tls_insecure,
+        db_options             => $icingadb::db_options,
         redis_tls              => $icingadb::redis_use_tls,
         redis_tls_cert         => $redis_tls_files['cert_file'],
         redis_tls_key          => $redis_tls_files['key_file'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,10 @@
 # @param db_tls_cacert_file
 #   Location of the CA root certificate. Only valid if `db_use_tls` is turned on.
 #
+# @param db_options
+#   List of low-level database options that can be set to influence some
+#   Icinga DB internal default behaviours.
+#
 # @param logging_level
 #   Specifies the default logging level. Can be set to fatal, error, warn, info or debug.
 #
@@ -145,6 +149,13 @@ class icingadb (
   Optional[Stdlib::Absolutepath]                 $db_tls_cert_file       = undef,
   Optional[Stdlib::Absolutepath]                 $db_tls_key_file        = undef,
   Optional[Stdlib::Absolutepath]                 $db_tls_cacert_file     = undef,
+  Hash[Enum[
+      'max_connections',
+      'max_connections_per_table',
+      'max_placeholders_per_statement',
+      'max_rows_per_transaction',
+      'wsrep_sync_wait'
+  ], Integer[1]]                                 $db_options             = {},
   Stdlib::Host                                   $redis_host             = 'localhost',
   Stdlib::Port                                   $redis_port             = 6380,
   Optional[Icinga::Secret]                       $redis_password         = undef,

--- a/templates/config.yml.epp
+++ b/templates/config.yml.epp
@@ -9,6 +9,7 @@
       Optional[String]                             $db_tls_key             = undef,
       Optional[String]                             $db_tls_cacert          = undef,
       Optional[Boolean]                            $db_tls_insecure        = undef,
+      Hash[String[1], Integer[1]]                  $db_options             = {},
       Stdlib::Host                                 $redis_host,
       Optional[Stdlib::Port]                       $redis_port             = undef,
       Optional[Variant[String, Sensitive[String]]] $redis_password         = undef,
@@ -49,6 +50,12 @@ database:
 <% } -%>
 <% if $db_tls_insecure =~ Boolean { -%>
   insecure: <%= $db_tls_insecure %>
+<% } -%>
+<% } -%>
+<% unless empty($db_options) { -%>
+  options:
+<% $db_options.each |String $opt, Integer $val| { -%>
+    <%= $opt %>: <%= $val %>
 <% } -%>
 <% } -%>
 


### PR DESCRIPTION
refs #35 

Options are described in
https://icinga.com/docs/icinga-db/latest/doc/03-Configuration/#database-options.