### PR TITLE
metadata.json: Allow puppet-redis 12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ This module supports:
 
 * [puppet] >= 7.9.0 < 9.0.0
 
-And requiers:
+And requires:
 
 * [puppetlabs/stdlib] >= 6.6.0 < 10.0.0
 * [icinga/icinga] >= 2.9.0 < 8.0.0
+* [puppet/redis] >= 8.2.0 < 13.0.0
 
 ### Beginning with icingadb
 

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 8.2.0 < 12.0.0"
+      "version_requirement": ">= 8.2.0 < 13.0.0"
     },
     {
       "name": "puppet/icinga",


### PR DESCRIPTION
#### Pull Request (PR) description

This increases the version requirement on the `puppet-redis` dependency to allow the use version 12.x.

#### This Pull Request (PR) fixes the following issues

N/A